### PR TITLE
BugFix: time_utils get_now_string report date instead of time

### DIFF
--- a/time_utils.py
+++ b/time_utils.py
@@ -9,5 +9,5 @@ def get_today_string():
 
 def get_now_string():
     localtime = time.localtime()
-    today = time.strftime("%Y-%m-%d", localtime)
+    today = time.strftime("%H:%M:%S", localtime)
     return today


### PR DESCRIPTION
During refactor, copy-paste error was introduced.
This patch fix this error.

Signed-off-by: Martial SALGUES firetux46@gmail.com
